### PR TITLE
Add multi as collection format for array types

### DIFF
--- a/lib/versions/2/index.js
+++ b/lib/versions/2/index.js
@@ -18,6 +18,11 @@ const collectFormats = {
 
   pipes(value) {
     return value.split('|');
+  },
+
+  multi(value) {
+    // ie: x=1&x=2&x=3 should equal [1,2,3], but if x=1 only, then make it an array
+    return Array.isArray(value) ? value : [value];
   }
 };
 


### PR DESCRIPTION
validator does not recognize `multi` as a valid array type and it should